### PR TITLE
Update info.plist

### DIFF
--- a/source/info.plist
+++ b/source/info.plist
@@ -486,10 +486,6 @@ function parseReminderQuery(query) {
 	for (var i = 0; i &lt; results.length; i++) {
 		resultText = query.replace(results[i].text,'');
 		var d = results[i].start.date(); // Create a Date object
-		// If date is in the past, assume intended date is tomorrow
-		if (d &lt; now) {
-			d.setDate(now.getDate() + 1);
-		}
 		var reminderText = resultText.trim();
 		items.push(getAction({arg:i, valid:true, reminderText:reminderText, date:d, whenText:results[i].text, priority:priority, reminderList:reminderList}));
 		reminders.push(getReminderData({arg:i, reminderText:reminderText, reminderBody:reminderBody, date:d, list:"", priority:priority, application:application, reminderList:reminderList}));


### PR DESCRIPTION
Fix the bug that `r tomorrow` and `r today` may get the same date( and possibly wrong).
Maybe this bug is related to [issue 67](https://github.com/surrealroad/alfred-reminders/issues/67) 

I found that `r today` would point to tomorrow when this workflow is used in the afternoon.
Sorry about not diving into the codes so much, but I guess the cause of the bug is that, `today` is actually point to "today 12:00", and `now` is actually point to "today now exactly". (**If a date is in the past, it just plus it by one.**) So in the afternoon, say 13:00, `today` is in the past(12:00 < 13:00).

A quick fix is to just delete the three lines of code(as I commit).

And also, I personally think Reminder should allow users to add reminds whose date is in the past.


